### PR TITLE
fix: minor template issues preventing a clean install

### DIFF
--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -69,8 +69,6 @@ Create the name of the service account to use
     {{- with .Values.customLabels }}
       {{- toYaml . }}
     {{- end }}
-  {{- else}}
-    {{ print "{}" }}
   {{- end }}
 {{- end -}}
 

--- a/charts/templates/clusterRoleBinding.yaml
+++ b/charts/templates/clusterRoleBinding.yaml
@@ -14,7 +14,7 @@ roleRef:
   name: {{ include "k6-operator.fullname" . }}-manager-role
 subjects:
   - kind: ServiceAccount
-    name: {{- include "k6-operator.serviceAccountName" . -}}
+    name: {{ include "k6-operator.serviceAccountName" . }}
     namespace: {{- include "k6-operator.namespace" . -}}
 {{- if .Values.authProxy.enabled }}
 ---
@@ -32,6 +32,6 @@ roleRef:
   name: {{ include "k6-operator.fullname" . }}-proxy-role
 subjects:
   - kind: ServiceAccount
-    name: {{- include "k6-operator.serviceAccountName" . -}}
+    name: {{ include "k6-operator.serviceAccountName" . }}
     namespace: {{- include "k6-operator.namespace" . -}}
 {{- end }}

--- a/charts/templates/roleBinding.yaml
+++ b/charts/templates/roleBinding.yaml
@@ -15,5 +15,5 @@ roleRef:
   name: {{ include "k6-operator.fullname" . }}-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.manager.serviceAccount }}
+  name: {{ .Values.manager.serviceAccount.name }}
   namespace: {{- include "k6-operator.namespace" . }}


### PR DESCRIPTION
Hey @knmsk , I've been tracking your PR on https://github.com/grafana/k6-operator/pull/98/files
First, thank you for doing this work; it saved me a ton of time to get the k6-operator installed via Helm!

I tried to install this in a new cluster by running `helm install ./path/topackage.tgz`, I kept getting small template formatting issues that I could fix by seeing the install output with `--dry-run` flag

With these fixes, I can get a clean install, and I successfully ran a k6 test via k8s using the newly installed operator.

I thought about proposing the changes here as I believe they can be helpful in reducing a few more bugs in the main PR linked above.

Have a good one!

